### PR TITLE
Fix `build.zig`. Make example depend on parent project.

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -53,7 +53,9 @@ pub fn build(b: *std.Build) !void {
 
     /////////////////////////////////////////////////////////////
     //// Refer to Cuda path manually during build i.e, -DCUDA_PATH
-    const cuda_path = b.option([]const u8, "CUDA_PATH", "locally installed Cuda's path");
+    const cuda_path =
+        b.option([]const u8, "CUDA_PATH", "locally installed Cuda's path") orelse
+        try std.process.getEnvVarOwned(b.allocator, "CUDA_PATH");
 
     /////////////////////////////////////////////////////////////
     //// Get Cuda paths

--- a/build.zig
+++ b/build.zig
@@ -54,9 +54,7 @@ pub fn build(b: *std.Build) !void {
 
     /////////////////////////////////////////////////////////////
     //// Refer to Cuda path manually during build i.e, -DCUDA_PATH
-    const cuda_path =
-        b.option([]const u8, "CUDA_PATH", "locally installed Cuda's path") orelse
-        try getCudaPathEnvVar(b.allocator);
+    const cuda_path = b.option([]const u8, "CUDA_PATH", "locally installed Cuda's path");
 
     /////////////////////////////////////////////////////////////
     //// Get Cuda paths
@@ -145,11 +143,4 @@ pub fn build(b: *std.Build) !void {
     // Register clean command i.e, zig build clean to cleanup any artifacts and cache
     const clean_cmd = b.step("clean", "Cleans the cache folders");
     clean_cmd.dependOn(&clean_step.step);
-}
-
-fn getCudaPathEnvVar(allocator: std.mem.Allocator) !?[]const u8 {
-    return std.process.getEnvVarOwned(allocator, "CUDA_PATH") catch |err| switch (err) {
-        error.EnvironmentVariableNotFound => null,
-        else => return err,
-    };
 }

--- a/build.zig
+++ b/build.zig
@@ -23,6 +23,7 @@ fn getCudaPath(path: ?[]const u8, allocator: std.mem.Allocator) ![]const u8 {
                 "/usr/local/cuda",
                 "/opt/cuda",
                 "/usr/lib/cuda",
+                "C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.3",
             };
             inline for (probable_roots) |parent| h: {
                 const cuda_file = parent ++ "/include/cuda.h";

--- a/build.zig
+++ b/build.zig
@@ -56,7 +56,7 @@ pub fn build(b: *std.Build) !void {
     //// Refer to Cuda path manually during build i.e, -DCUDA_PATH
     const cuda_path =
         b.option([]const u8, "CUDA_PATH", "locally installed Cuda's path") orelse
-        try std.process.getEnvVarOwned(b.allocator, "CUDA_PATH");
+        try getCudaPathEnvVar(b.allocator);
 
     /////////////////////////////////////////////////////////////
     //// Get Cuda paths
@@ -145,4 +145,11 @@ pub fn build(b: *std.Build) !void {
     // Register clean command i.e, zig build clean to cleanup any artifacts and cache
     const clean_cmd = b.step("clean", "Cleans the cache folders");
     clean_cmd.dependOn(&clean_step.step);
+}
+
+fn getCudaPathEnvVar(allocator: std.mem.Allocator) !?[]const u8 {
+    return std.process.getEnvVarOwned(allocator, "CUDA_PATH") catch |err| switch (err) {
+        error.EnvironmentVariableNotFound => null,
+        else => return err,
+    };
 }

--- a/build.zig
+++ b/build.zig
@@ -9,11 +9,9 @@ fn getCudaPath(path: ?[]const u8, allocator: std.mem.Allocator) ![]const u8 {
         if (path) |parent| {
             const cuda_file = try std.fmt.allocPrint(allocator, "{s}/include/cuda.h", .{parent});
             defer allocator.free(cuda_file);
-            _ = std.fs.openDirAbsolute(cuda_file, .{}) catch |e| {
+            _ = std.fs.openFileAbsolute(cuda_file, .{}) catch |e| {
                 switch (e) {
-                    std.fs.File.OpenError.FileNotFound => {
-                        return error.CUDA_INSTALLATION_NOT_FOUND;
-                    },
+                    std.fs.File.OpenError.FileNotFound => return error.CUDA_INSTALLATION_NOT_FOUND,
                     else => return e,
                 }
             };

--- a/example/increment/build.zig
+++ b/example/increment/build.zig
@@ -5,7 +5,10 @@ pub fn build(b: *std.Build) !void {
     const exe = b.addExecutable(.{ .name = "main", .root_source_file = .{ .path = "src/main.zig" }, .target = b.host });
 
     // Point to cudaz dependency
-    const cudaz_dep = b.dependency("cudaz", .{});
+    const cudaz_dep = b.dependency(
+        "cudaz",
+        .{}, // replace with `.{ .CUDA_PATH = @as([]const u8, "<your cuda path>") }` to specify custom CUDA_PATH
+    );
 
     // Fetch and add the module from cudaz dependency
     const cudaz_module = cudaz_dep.module("cudaz");

--- a/example/increment/build.zig.zon
+++ b/example/increment/build.zig.zon
@@ -16,7 +16,7 @@
     // internet connectivity.
     .dependencies = .{
         .cudaz = .{
-            .url = "https://github.com/akhildevelops/cudaz/tarball/master",
+            .url = "https://github.com/akhildevelops/cudaz/tarball/main",
             .hash = "122042f55e5b492702d91ac0c09f0d74c7a1842a19ef2e75c1a833d64df51a0be9eb",
         },
     },

--- a/example/increment/build.zig.zon
+++ b/example/increment/build.zig.zon
@@ -16,8 +16,9 @@
     // internet connectivity.
     .dependencies = .{
         .cudaz = .{
-            .url = "https://github.com/akhildevelops/cudaz/tarball/main",
-            .hash = "122042f55e5b492702d91ac0c09f0d74c7a1842a19ef2e75c1a833d64df51a0be9eb",
+            // .url = "https://github.com/DanikVitek/cudaz/tarball/main",
+            // .hash = "12207c8be3e4fa2cec0a24ab820b431ca9a6ccc484987d751d354ad6a58df97f6802",
+            .path = "../../",
         },
     },
     .paths = .{

--- a/example/increment/build.zig.zon
+++ b/example/increment/build.zig.zon
@@ -16,7 +16,7 @@
     // internet connectivity.
     .dependencies = .{
         .cudaz = .{
-            // .url = "https://github.com/DanikVitek/cudaz/tarball/main",
+            // .url = "https://github.com/akhildevelops/cudaz/tarball/main",
             // .hash = "12207c8be3e4fa2cec0a24ab820b431ca9a6ccc484987d751d354ad6a58df97f6802",
             .path = "../../",
         },

--- a/example/increment/src/increment.cu
+++ b/example/increment/src/increment.cu
@@ -1,0 +1,5 @@
+extern "C" __global__ void increment(float *out)
+{
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    out[i] = out[i] + 1;
+}

--- a/example/increment/src/main.zig
+++ b/example/increment/src/main.zig
@@ -5,13 +5,7 @@ const CuCompile = Cuda.Compile;
 const CuLaunchConfig = Cuda.LaunchConfig;
 
 // Cuda Kernel
-const increment_kernel =
-    \\extern "C" __global__ void increment(float *out)
-    \\{
-    \\    int i = blockIdx.x * blockDim.x + threadIdx.x;
-    \\    out[i] = out[i] + 1;
-    \\}
-;
+const increment_kernel = @embedFile("./increment.cu");
 
 pub fn main() !void {
     // Initialize allocator
@@ -31,6 +25,7 @@ pub fn main() !void {
     std.debug.print("Copied array {d:.3} from system to GPU\n", .{data});
 
     // Compile and load the Kernel
+    std.debug.print("Kernel program:\n{s}\n\n", .{increment_kernel});
     const ptx = try CuCompile.cudaText(increment_kernel, .{}, allocator);
     defer allocator.free(ptx);
     const module = try CuDevice.loadPtxText(ptx);

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -8,4 +8,4 @@ pub const CAPI = @import("c.zig");
 pub usingnamespace @import("path.zig");
 pub const Rng = @import("rng.zig");
 const Error = @import("error.zig");
-pub const CudaError = Error.CurandError.Error || Error.NvrtcError.Error || Error.NvrtcError.Error;
+pub const CudaError = Error.CurandError.Error || Error.NvrtcError.Error;


### PR DESCRIPTION
- Use `openFileAbsolute` instead of `openDirAbsolute` for `cuda.h`.
- Add Windows' path to CUDA installation
- Remove duplicate error set from the `CudaError` union.
- Use `@embedFile` instead of inline kernel sources.
- Make examples' `cudaz` dependency into a relative path, instead of git commit.