### PR TITLE
update for zig 14

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,5 +1,5 @@
 ![AI Generated](cuda_zig.jpeg)
-# A Zig Cuda wrapper
+# Cuda library for Zig
 ### Works with latest zig v0.12.0
 This library helps to interact with NVIDIA GPUs from zig. Provides high level interface to communicate with GPU. It can detect cuda installation and link to a project's binary on Linux/MacOS. Check [Customization](https://github.com/akhildevelops/cudaz/tree/main#Customization) to give cuda manual path.
 

--- a/build.zig
+++ b/build.zig
@@ -63,8 +63,8 @@ pub fn build(b: *std.Build) !void {
 
     ////////////////////////////////////////////////////////////
     //// CudaZ Module
-    const cudaz_module = b.addModule("cudaz", .{ .root_source_file = .{ .path = "src/lib.zig" } });
-    cudaz_module.addIncludePath(.{ .path = cuda_include_dir });
+    const cudaz_module = b.addModule("cudaz", .{ .root_source_file = b.path("./src/lib.zig") });
+    cudaz_module.addIncludePath(.{ .cwd_relative = cuda_include_dir });
 
     const lib_paths = [_][]const u8{
         "lib",
@@ -81,7 +81,7 @@ pub fn build(b: *std.Build) !void {
 
     inline for (lib_paths) |lib_path| {
         const path = try std.fmt.allocPrint(b.allocator, "{s}/{s}", .{ cuda_folder, lib_path });
-        cudaz_module.addLibraryPath(.{ .path = path });
+        cudaz_module.addLibraryPath(.{ .cwd_relative = path });
     }
 
     ////////////////////////////////////////////////////////////
@@ -108,7 +108,7 @@ pub fn build(b: *std.Build) !void {
         while (try dir_iterator.next()) |item| {
             if (item.kind == .file) {
                 const test_path = try std.fmt.allocPrint(b.allocator, "{s}/{s}", .{ "test", item.path });
-                const sub_test = b.addTest(.{ .name = item.path, .root_source_file = .{ .path = test_path }, .target = target, .optimize = optimize });
+                const sub_test = b.addTest(.{ .name = item.path, .root_source_file = b.path(test_path), .target = target, .optimize = optimize });
                 // Add Module
                 sub_test.root_module.addImport("cudaz", cudaz_module);
 
@@ -135,7 +135,7 @@ pub fn build(b: *std.Build) !void {
     //// Clean the cache folders and artifacts
 
     // Creates a binary that cleans up zig artifact folders
-    const clean = b.addExecutable(.{ .name = "clean", .root_source_file = .{ .path = "bin/delete-zig-cache.zig" }, .target = target, .optimize = optimize });
+    const clean = b.addExecutable(.{ .name = "clean", .root_source_file = b.path("bin/delete-zig-cache.zig"), .target = target, .optimize = optimize });
 
     // Creates a run step
     const clean_step = b.addRunArtifact(clean);

--- a/example/custom_type/build.zig
+++ b/example/custom_type/build.zig
@@ -2,8 +2,8 @@ const std = @import("std");
 
 pub fn build(b: *std.Build) !void {
     // exe points to main.zig that uses cudaz
-    const exe = b.addExecutable(.{ .name = "main", .root_source_file = .{ .path = "src/main.zig" }, .target = b.host });
-    exe.addIncludePath(.{ .path = "c" });
+    const exe = b.addExecutable(.{ .name = "main", .root_source_file = b.path("src/main.zig"), .target = b.host });
+    exe.addIncludePath(b.path("c"));
     // Point to cudaz dependency
     const cudaz_dep = b.dependency(
         "cudaz",

--- a/example/increment/build.zig
+++ b/example/increment/build.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 
 pub fn build(b: *std.Build) !void {
     // exe points to main.zig that uses cudaz
-    const exe = b.addExecutable(.{ .name = "main", .root_source_file = .{ .path = "src/main.zig" }, .target = b.host });
+    const exe = b.addExecutable(.{ .name = "main", .root_source_file = b.path("src/main.zig"), .target = b.host });
 
     // Point to cudaz dependency
     const cudaz_dep = b.dependency(


### PR DESCRIPTION
zig 14 dev has some breaking changes to the build file. Pretty much the biggest change is `root_source_file` should use a `b.path("src/file.zig")` as an input, rather than `.{ .path = "src/file.zig" }`. This fixes those!