### PR TITLE
Expose module and function from lib

### DIFF
--- a/src/lib.zig
+++ b/src/lib.zig
@@ -1,6 +1,8 @@
 const wrappers = @import("wrappers.zig");
 const utils = @import("utils.zig");
 pub const Cudaslice = wrappers.CudaSlice;
+pub const Module = wrappers.Module;
+pub const Function = wrappers.Function;
 pub const Device = @import("device.zig");
 pub const Compile = @import("compile.zig");
 pub const LaunchConfig = @import("launchconfig.zig").LaunchConfig;


### PR DESCRIPTION
Exposed module and function from lid.zig for usage in function signatures. In my case, they are used for cashing loaded ptx.